### PR TITLE
Bump to v0.4.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Kinetica"
 uuid = "3847ce11-53ec-444b-aa85-3b6606472139"
 authors = ["joegilkes <j.gilkes@warwick.ac.uk>"]
-version = "0.3.3"
+version = "0.4.0"
 
 [deps]
 BSON = "fbb218c0-5317-5bc6-957e-2ee96dd4b1f0"

--- a/src/Kinetica.jl
+++ b/src/Kinetica.jl
@@ -1,3 +1,8 @@
+"""
+Kinetica.jl
+
+UK Ministry of Defence © Crown Owned Copyright 2024/AWE​
+"""
 module Kinetica
 
 using Logging


### PR DESCRIPTION
Allows for early return of integrator from `solve_network` using the `return_integrator` argument. When this is `true`, the solution can be stepped through manually using the CommonSolve integrator interface.