### PR TITLE
Force CompatHelper to use newest Julia

### DIFF
--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -10,16 +10,8 @@ jobs:
   CompatHelper:
     runs-on: ubuntu-latest
     steps:
-      - name: Check if Julia is already available in the PATH
-        id: julia_in_path
-        run: which julia
-        continue-on-error: true
-      - name: Install Julia, but only if it is not already available in the PATH
-        uses: julia-actions/setup-julia@v1
-        with:
-          version: '1'
-          arch: ${{ runner.arch }}
-        if: steps.julia_in_path.outcome != 'success'
+      - name: Install Julia
+        uses: julia-actions/setup-julia@latest
       - name: "Add registries"
         run: |
           import Pkg


### PR DESCRIPTION
CompatHelper was failing to run due to `RegistrySpec` not being recognised, as it was using an older version of Julia. This forces installation of the newest version of Julia, such that `RegistrySpec` is allowed.