### PR TITLE
Fixed overwriting of `profile.f`/`profile.grad` methods in condition profiles

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Kinetica"
 uuid = "3847ce11-53ec-444b-aa85-3b6606472139"
 authors = ["joegilkes <j.gilkes@warwick.ac.uk>"]
-version = "0.5.6"
+version = "0.5.7"
 
 [deps]
 BSON = "fbb218c0-5317-5bc6-957e-2ee96dd4b1f0"

--- a/docs/src/development/condition-profiles.md
+++ b/docs/src/development/condition-profiles.md
@@ -30,11 +30,18 @@ As noted previously, variable condition profiles can take on one of two types of
 
 Both types of variable condition profile are simple to implement within Kinetica, provided a few criteria are fulfilled:
 
-* Both are implemented as structs with supertypes as above that indicate how Kinetica should handle them. These structs must have a number of fields, but are otherwise entirely customisable for whatever data needs to be held.
-* Both types of struct usually come with outer constructors that handle the writing of a custom direct/gradient function that are then stored within the struct.
+* Both are implemented as structs with supertypes as above that indicate how Kinetica should handle them. These structs must have a number of fields, but are otherwise entirely customisable for whatever data needs to be held. These usually come with outer constructors that create variables that are needed within the profile's condition function, as well as binding a condition function to one of the struct's fields.
+* A condition function (usually called `_f_[struct name]` for direct condition profiles or `_grad_[struct_name]` for gradient condition profiles) must exist such that it can be bound to a condition profile struct. This function takes two arguments - the time `t` and the `profile` that it will ultimately be bound to.
 * A method of [`Kinetica.create_discrete_tstops!`](@ref) must be created for the new profile struct which tells Kinetica where rate constants should be updated in discrete rate constant update simulations.
 
 We'll demonstrate this by implementing both directly variable and gradient-variable versions of a simple sinusoidal condition profile.
+
+!!! note "Why not a functor?"
+    The implementation of condition functions described above may look a bit strange. Variable condition profiles require condition functions that always take the same arguments for internal consistency, but are also capable of taking a potentially large number of runtime-defined parameters that are accessible from some kind of `Kinetica.AbstractVariableProfile`. Why then do we pass a condition function as a field of the profile struct during construction and then pass the struct *back* to that function instead of using a [functor](https://docs.julialang.org/en/v1/manual/methods/#Function-like-objects), which would seemingly fill both of these roles?
+
+    While the functor approach would certainly be more convenient, it's currently incompatible with [Symbolics.jl](https://github.com/JuliaSymbolics/Symbolics.jl) (more specifically its function registration API), which Kinetica uses to programatically embed variable condition profiles into systems of ODEs. Instead, we are forced to use a regular function, which then takes its parameters from a condition profile struct such that its call signature is always `conditionfunc(t, profile::AbstractVariableProfile)`. This function is bound to its respective condition profile struct so that irrespective of its true name, it is always accessible through `profile.f` for direct profiles, and `profile.grad` for gradient profiles.
+
+    Similarly, we could define condition functions within the outer constructors, allowing them to implicitly make use of profile variables defined within the constructor and eliminating the need to pass an instance of the profile struct as an argument. However, due to how functions are registered within Symbolics, this can lead to condition functions overwriting one another. The separate condition function approach is admittedly a bit cumbersome, but it is currently the best viable approach that allows for hands-off creation of [`ConditionSet`](@ref)s for users.
 
 ## Directly Variable Profile Implementation
 
@@ -46,13 +53,13 @@ where ``A`` is the amplitude and ``f`` is the number of oscillations per second.
 
 We will begin by creating the struct for our condition profile, which we'll call `SinusoidDirectProfile`. Aside from the parameters above, we'll also need to implement fields for some basics which Kinetica expects in every directly variable profile:
 
-* `f`: The function which will be created in the struct's outer constructor.
+* `f`: The function which will be bound in the struct's outer constructor.
 * `X_start`: The initial value of the condition profile.
 * `t_end`: The time at which the condition profile should stop varying. This can either be provided by the user or calculated within the outer constructor.
 * `tstops`: Time points at which ODE solvers should ensure to stop at and recalculate. This array is useful for handling discontinuities in condition profiles, and is usually modified by [`Kinetica.create_discrete_tstops!`](@ref).
 * `sol`: Profile solution over the requested timespan, usually created internally by calling [`Kinetica.solve_variable_condition!(::Kinetica.AbstractDirectProfile, ::ODESimulationParams)`](@ref).
 
-Some condition profiles also implement a field `X_end` to signify the value of the condition which must be reached before the condition stops varying. However, this is not a necessary field and is only used for calculating the value of `t_end`. As a sinusoidal profile is periodic and may reach the same value multiple times, this definition makes less sense and we will provide `t_end` directly.
+For this profile, we will also implement a field `X_end` to signify the value of the condition once it stops varying. In some profiles, this is more easily calculated by the profile itself, e.g. as a function of time when `t_end` is given. Conversely, in other profiles, it can be convenient to only provide `X_end` and let `t_end` be calculated instead. As a sinusoidal profile is periodic and may reach the same value multiple times, users will provide `t_end` directly and we will calculate and save the value of `X_end` in the outer constructor.
 
 An implementation of our condition profile's struct may therefore look something like:
 
@@ -74,9 +81,17 @@ nothing # hide
 
 We've used a [parametric type](https://docs.julialang.org/en/v1/manual/types/#Parametric-Types) here to ensure that all values that may affect the value of our condition are using consistent numeric types.
 
-With this definition complete, we can now define our condition profile's outer constructor. This will take in the user-facing parameters of the profile and create a function that represents the sinusoid we want to create:
+With this definition complete, we can now define our profile's condition function and outer constructor. The condition function will take a time `t` and an instance of the `SinusoidDirectProfile`. The outer constructor will take a minimal set of parameters needed to populate and calculate the entire condition profile, and create an instance of the profile with the condition function bound to the `f` field:
 
 ```@example condition_profiles
+function _f_SinusoidDirectProfile(t, profile::SinusoidDirectProfile)
+    return typeof(profile.X_start)(
+        ((t <= 0.0) * profile.X_start) +
+        ((t > 0.0 && t <= profile.t_end) * (profile.X_start + profile.A*sin(2*pi*profile.freq*t))) + 
+        ((t > profile.t_end) * profile.X_end)
+    )
+end
+
 function SinusoidDirectProfile(;
     A::uType,
     freq::uType,
@@ -87,35 +102,27 @@ function SinusoidDirectProfile(;
     X_end = X_start + A*sin(2*pi*freq*t_end)
     tstops = [t_end]
 
-    Kinetica._n_direct_condition_functions += 1
-    funcname = Symbol(:direct_func_, Kinetica._n_direct_condition_functions)
-    @eval function $(funcname)(t, profile)
-        return typeof(profile.X_start)(
-            ((t <= 0.0) * profile.X_start) +
-            ((t > 0.0 && t <= profile.t_end) * (profile.X_start + profile.A*sin(2*pi*profile.freq*t))) + 
-            ((t > profile.t_end) * profile.X_end)
-        )
-    end
-    f = @eval $(funcname)
-
-    return SinusoidDirectProfile(f, A, freq, X_start, X_end, t_end, tstops, nothing)
+    return SinusoidDirectProfile(_f_SinusoidDirectProfile, A, freq, X_start, X_end, t_end, tstops, nothing)
 end
 nothing # hide
 ```
 
-How we've defined `f(t)` here may look a little strange. This is actually a way of writing if-else statements that is compatible with [Symbolics.jl](https://github.com/JuliaSymbolics/Symbolics.jl), and is equivalent to writing
+How we've defined `_f_SinusoidDirectProfile(t, profile)` here may look a little strange. This is actually a way of writing if-else statements that is compatible with [Symbolics.jl](https://github.com/JuliaSymbolics/Symbolics.jl), and is equivalent to writing
 ```julia
-function f(t)
+function _f_SinusoidDirectProfile(t, profile::SinusoidDirectProfile)
     if t <= 0.0
-        return X_start
-    elseif t > 0.0 && t <= t_end
-        return X_start + A*sin(2*pi*freq*t)
+        return profile.X_start
+    elseif t > 0.0 && t <= profile.t_end
+        return profile.X_start + profile.A*sin(2*pi*profile.freq*t)
     else
-        return X_end
+        return profile.X_end
     end
 end
 ```
-However, Symbolics isn't compatible with real if-else statements so instead we use a bit of boolean algebra to embed the same meaning into our condition function. We've therefore assumed that simulation time will start at `t=0.0`, before which time the condition will be `X_start`. After `t_end`, the condition profile will stop varying and be set to the value of the sinusoid at this time. In between these two times, we take the instantaneous value of the sinusoid instead.
+However, Symbolics isn't compatible with this form of if-else statement so instead we use a bit of boolean algebra to embed the same meaning into our condition function. We've therefore assumed that simulation time will start at `t=0.0`, before which time the condition will be `X_start`. After `t_end`, the condition profile will stop varying and be set to the value of the sinusoid at this time. In between these two times, we take the instantaneous value of the sinusoid instead.
+
+!!! note "Naming Condition Functions"
+    Condition functions do not have to take any particular names, although Kinetica generally follows the pattern set above. Starting with an underscore indicates that the function is not intended for general use, the `f` (or `grad` in the case of gradient functions) specifies the type of variable condition profile that it attaches to, and the name of the condition profile indicates that it should only be used in the context of that particular profile.
 
 Finally, we need to define a method of [`Kinetica.create_discrete_tstops!`](@ref) for our new profile. This function creates time stopping points for discrete rate update simulations. Some profiles contain periods of time where their condition is stationary, during which rate constant updates are unnecessary, so their method of this function can avoid creating time points during these periods. However, since the gradient of a sinusoid is only ever momentarily stationary, this optimisation is not necessary. Our implementation of this method is therefore as follows:
 
@@ -150,7 +157,7 @@ conditions = ConditionSet(Dict(
 nothing # hide
 ```
 
-Because we've made `SinusoidDirectProfile` a subtype of `Kinetica.AbstractDirectProfile`, Kinetica's [`ConditionSet`](@ref) has done a bunch of work in the background and set this profile up for use within Symbolics.jl by [registering](https://symbolics.juliasymbolics.org/stable/manual/functions/) the generated `SinusoidDirectProfile.f` function into Symbolics' computation graph. This means it's ready for use within kinetic simulations, just like that!
+Because we've made `SinusoidDirectProfile` a subtype of `Kinetica.AbstractDirectProfile`, Kinetica's [`ConditionSet`](@ref) has done a bunch of work in the background and set this profile up for use within Symbolics.jl by [registering](https://symbolics.juliasymbolics.org/stable/manual/functions/) the generated `SinusoidDirectProfile.f` function (which is really just a reference to `_f_SinusoidDirectProfile`) into Symbolics' computation graph. This means it's ready for use within kinetic simulations, just like that!
 
 ```@example condition_profiles
 pars.tspan = (0.0, get_t_final(conditions)) # hide
@@ -207,9 +214,17 @@ end
 nothing # hide
 ```
 
-The outer constructor for this profile will also be similar to its directly variable counterpart, again with an extra parameter `φ` added:
+The condition function and outer constructor for this profile will also be similar to their directly variable counterparts, again with an extra parameter `φ` added:
 
 ```@example condition_profiles
+function _grad_SinusoidGradientProfile(t, profile::SinusoidGradientProfile)
+    return typeof(profile.X_start)(
+        ((t <= 0.0) * 0.0) +
+        ((t > 0.0 && t <= profile.t_end) * (2*pi*profile.freq*profile.A*cos(2*pi*profile.freq*t + profile.φ))) + 
+        ((t > profile.t_end) * 0.0)
+    )
+end
+
 function SinusoidGradientProfile(;
     A::uType,
     freq::uType,
@@ -218,20 +233,8 @@ function SinusoidGradientProfile(;
     t_end::tType
 ) where {uType <: AbstractFloat, tType <: AbstractFloat}
 
-    Kinetica._n_gradient_condition_functions += 1
-    funcname = Symbol(:gradient_func_, Kinetica._n_gradient_condition_functions)
-    @eval function $(funcname)(t, profile)
-        return typeof(profile.X_start)(
-            ((t <= 0.0) * 0.0) +
-            ((t > 0.0 && t <= profile.t_end) * (2*pi*profile.freq*profile.A*cos(2*pi*profile.freq*t + profile.φ))) + 
-            ((t > profile.t_end) * 0.0)
-        )
-    end
-    grad = @eval $(funcname)
-
     tstops = [t_end]
-
-    return SinusoidGradientProfile(grad, A, freq, φ, X_start, t_end, tstops, nothing)
+    return SinusoidGradientProfile(_grad_SinusoidGradientProfile, A, freq, φ, X_start, t_end, tstops, nothing)
 end
 nothing # hide
 ```

--- a/src/Kinetica.jl
+++ b/src/Kinetica.jl
@@ -56,6 +56,11 @@ function __init__()
 end
 export pybel, obcr, rdChem
 
+# Global AbstractVariableProfile counters.
+# Ensures non-overlapping profile function names.
+_n_direct_condition_functions = 0
+_n_gradient_condition_functions = 0
+
 include("constants.jl")
 using .Constants
 

--- a/src/Kinetica.jl
+++ b/src/Kinetica.jl
@@ -29,8 +29,6 @@ using OrderedCollections
 using PythonCall
 using CDE_jll
 
-const version = VersionNumber(0, 5, 6)
-
 # Global Python package interfaces
 const pybel = PythonCall.pynew()
 const obcr = PythonCall.pynew()

--- a/src/Kinetica.jl
+++ b/src/Kinetica.jl
@@ -56,11 +56,6 @@ function __init__()
 end
 export pybel, obcr, rdChem
 
-# Global AbstractVariableProfile counters.
-# Ensures non-overlapping profile function names.
-_n_direct_condition_functions = 0
-_n_gradient_condition_functions = 0
-
 include("constants.jl")
 using .Constants
 

--- a/src/analysis/io.jl
+++ b/src/analysis/io.jl
@@ -105,7 +105,7 @@ function save_output(out::ODESolveOutput, saveto::String)
     end
 
     savedict = Dict(
-        :KineticaCoreVersion => version,
+        :KineticaCoreVersion => pkgversion(Kinetica),
         :sd => Dict(
             :toInt => out.sd.toInt,
             :n => out.sd.n,
@@ -168,10 +168,10 @@ for details.
 """
 function load_output(outfile::String)
     savedict = BSON.load(outfile)
-    if savedict[:KineticaCoreVersion] < version
-        @warn "Loaded network output was made in a previous version of KineticaCore, reconstructed output may not be fully compatible."
-    elseif savedict[:KineticaCoreVersion] > version
-        @warn "Loaded network output was made in a newer version of KineticaCore, reconstructed output may not be fully compatible."
+    if savedict[:KineticaCoreVersion] < pkgversion(Kinetica)
+        @warn "Loaded network output was made in a previous version of Kinetica.jl, reconstructed output may not be fully compatible."
+    elseif savedict[:KineticaCoreVersion] > pkgversion(Kinetica)
+        @warn "Loaded network output was made in a newer version of Kinetica.jl, reconstructed output may not be fully compatible."
     end
 
     sd_iType = typeof(savedict[:sd][:n])

--- a/src/conditions/condition_set.jl
+++ b/src/conditions/condition_set.jl
@@ -205,7 +205,7 @@ function register_direct_conditions(cs::ConditionSet)
     for sym in cs.symbols
         profile = get_profile(cs, sym)
         if isvariable(profile) && isdirectprofile(profile)
-            eval(:(@register_symbolic($profile.f(t))))
+            eval(:(@register_symbolic($profile.f(t, p::AbstractDirectProfile))))
         end
     end
 end
@@ -224,7 +224,7 @@ function register_gradient_conditions(cs::ConditionSet)
     for sym in cs.symbols
         profile = get_profile(cs, sym)
         if isvariable(profile) && isgradientprofile(profile)
-            eval(:(@register_symbolic($profile.grad(t))))
+            eval(:(@register_symbolic($profile.grad(t, p::AbstractGradientProfile))))
         end
     end
 end

--- a/src/conditions/condition_set.jl
+++ b/src/conditions/condition_set.jl
@@ -205,7 +205,8 @@ function register_direct_conditions(cs::ConditionSet)
     for sym in cs.symbols
         profile = get_profile(cs, sym)
         if isvariable(profile) && isdirectprofile(profile)
-            eval(:(@register_symbolic($profile.f(t, p::AbstractDirectProfile))))
+            pType = typeof(profile)
+            eval(:(@register_symbolic($profile.f(t, p::$pType))))
         end
     end
 end
@@ -224,7 +225,8 @@ function register_gradient_conditions(cs::ConditionSet)
     for sym in cs.symbols
         profile = get_profile(cs, sym)
         if isvariable(profile) && isgradientprofile(profile)
-            eval(:(@register_symbolic($profile.grad(t, p::AbstractGradientProfile))))
+            pType = typeof(profile)
+            eval(:(@register_symbolic($profile.grad(t, p::$pType))))
         end
     end
 end

--- a/src/conditions/direct_variable.jl
+++ b/src/conditions/direct_variable.jl
@@ -55,7 +55,7 @@ mutable struct NullDirectProfile{uType, tType} <: AbstractDirectProfile
 end
 
 """
-    NullDirectProfile(; X, t_end)
+    NullDirectProfile(; X_start, t_end)
     
 Container for null direct profile data and condition function.
 

--- a/src/conditions/direct_variable.jl
+++ b/src/conditions/direct_variable.jl
@@ -74,19 +74,19 @@ Contains fields for:
 * Profile solution, constructed by call to `solve_variable_condition!` (`sol`)
 """
 function NullDirectProfile(;
-    X::uType,
+    X_start::uType,
     t_end::tType,
 ) where {uType <: AbstractFloat, tType <: AbstractFloat} 
     Kinetica._n_direct_condition_functions += 1
     funcname = Symbol(:direct_func_, Kinetica._n_direct_condition_functions)
     @eval function $(funcname)(t, profile)
-        return profile.X
+        return profile.X_start
     end
     f = @eval $(funcname)
 
     tstops = [t_end]
 
-    return NullDirectProfile(f, X, t_end, tstops, nothing)
+    return NullDirectProfile(f, X_start, t_end, tstops, nothing)
 end
 
 function create_discrete_tstops!(profile::NullDirectProfile, ts_update::AbstractFloat)

--- a/src/conditions/gradient_variable.jl
+++ b/src/conditions/gradient_variable.jl
@@ -75,7 +75,7 @@ mutable struct NullGradientProfile{uType, tType} <: AbstractGradientProfile
 end
 
 """
-    NullGradientProfile(; X, t_end)
+    NullGradientProfile(; X_start, t_end)
 
 Container for null gradient profile data and gradient function.
 

--- a/src/solving/methods.jl
+++ b/src/solving/methods.jl
@@ -384,9 +384,9 @@ function solve_network(method::VariableODESolve, sd::SpeciesData, rd::RxData, ::
     for sym in keys(vc_symmap)
         prof = get_profile(method.conditions, sym)
         if isdirectprofile(prof)
-            push!(direct_profiles, vc_symmap[sym] ~ prof.f(t))
+            push!(direct_profiles, vc_symmap[sym] ~ prof.f(t, prof))
         elseif isgradientprofile(prof)
-            push!(gradient_profiles, D(vc_symmap[sym]) ~ prof.grad(t))
+            push!(gradient_profiles, D(vc_symmap[sym]) ~ prof.grad(t, prof))
             push!(gradient_profile_symbols, sym)
         else
             throw(ErrorException("Undefined condition profile type. Something is very wrong..."))
@@ -479,9 +479,9 @@ function solve_network(method::VariableODESolve, sd::SpeciesData, rd::RxData, ::
     for sym in keys(vc_symmap)
         prof = get_profile(method.conditions, sym)
         if isdirectprofile(prof)
-            push!(direct_profiles, vc_symmap[sym] ~ prof.f(t + (chunktime * n_chunks)))
+            push!(direct_profiles, vc_symmap[sym] ~ prof.f(t + (chunktime * n_chunks), prof))
         elseif isgradientprofile(prof)
-            push!(gradient_profiles, D(vc_symmap[sym]) ~ prof.grad(t + (chunktime * n_chunks)))
+            push!(gradient_profiles, D(vc_symmap[sym]) ~ prof.grad(t + (chunktime * n_chunks), prof))
             push!(gradient_profile_symbols, sym)
         else
             throw(ErrorException("Undefined condition profile type. Something is very wrong..."))

--- a/test/Main/conditions.jl
+++ b/test/Main/conditions.jl
@@ -10,7 +10,7 @@ using Kinetica
         t_end = 10.0)
     @test nulldirect.X_start == 300.0
     @test nulldirect.t_end == 10.0
-    @test nulldirect.f(5.0) ≈ 300.0
+    @test nulldirect.f(5.0, nulldirect) ≈ 300.0
     @test length(nulldirect.tstops) == 1
     @test nulldirect.tstops[1] ≈ 10.0
 
@@ -22,7 +22,7 @@ using Kinetica
     @test lineardirect.X_start == 300.0
     @test lineardirect.X_end == 500.0
     @test lineardirect.t_end ≈ 4.0
-    @test lineardirect.f(2.0) ≈ 400.0
+    @test lineardirect.f(2.0, lineardirect) ≈ 400.0
     @test length(lineardirect.tstops) == 1
     @test lineardirect.tstops[1] ≈ 4.0
 
@@ -31,7 +31,7 @@ using Kinetica
         t_end = 10.0)
     @test nullgradient.X_start == 300.0
     @test nullgradient.t_end == 10.0
-    @test nullgradient.grad(5.0) == 0.0
+    @test nullgradient.grad(5.0, nullgradient) == 0.0
     @test length(nullgradient.tstops) == 1
     @test nullgradient.tstops[1] ≈ 10.0
 
@@ -43,8 +43,8 @@ using Kinetica
     @test lineargradient.X_start == 300.0
     @test lineargradient.X_end == 500.0
     @test lineargradient.t_end ≈ 4.0
-    @test lineargradient.grad(2.0) == 50.0
-    @test lineargradient.grad(5.0) == 0.0
+    @test lineargradient.grad(2.0, lineargradient) == 50.0
+    @test lineargradient.grad(5.0, lineargradient) == 0.0
     @test length(lineargradient.tstops) == 1
     @test lineargradient.tstops[1] ≈ 4.0
 
@@ -68,12 +68,12 @@ using Kinetica
     @test doublerampgradient.t_blend == 0.0
     @test doublerampgradient.t_end ≈ 48.0
     @test doublerampgradient.tstops ≈ [5.0, 25.0, 28.0, 43.0, 48.0]
-    @test doublerampgradient.grad(1.0) == 0.0
-    @test doublerampgradient.grad(15.0) == 10.0
-    @test doublerampgradient.grad(27.0) == 0.0
-    @test doublerampgradient.grad(35.0) == -20.0
-    @test doublerampgradient.grad(45.0) == 0.0
-    @test doublerampgradient.grad(100.0) == 0.0
+    @test doublerampgradient.grad(1.0, doublerampgradient) == 0.0
+    @test doublerampgradient.grad(15.0, doublerampgradient) == 10.0
+    @test doublerampgradient.grad(27.0, doublerampgradient) == 0.0
+    @test doublerampgradient.grad(35.0, doublerampgradient) == -20.0
+    @test doublerampgradient.grad(45.0, doublerampgradient) == 0.0
+    @test doublerampgradient.grad(100.0, doublerampgradient) == 0.0
 
     doublerampgradientblended = DoubleRampGradientProfile(;
         X_start = 300.0,

--- a/test/Main/conditions.jl
+++ b/test/Main/conditions.jl
@@ -27,7 +27,7 @@ using Kinetica
     @test lineardirect.tstops[1] ≈ 4.0
 
     nullgradient = Kinetica.NullGradientProfile(;
-        X = 300.0,
+        X_start = 300.0,
         t_end = 10.0)
     @test nullgradient.X_start == 300.0
     @test nullgradient.t_end == 10.0

--- a/test/Main/conditions.jl
+++ b/test/Main/conditions.jl
@@ -6,7 +6,7 @@ using Kinetica
     @test static.value == 10.0
 
     nulldirect = Kinetica.NullDirectProfile(;
-        X = 300.0, 
+        X_start = 300.0, 
         t_end = 10.0)
     @test nulldirect.X_start == 300.0
     @test nulldirect.t_end == 10.0


### PR DESCRIPTION
Since all versions of `AbstractDirectProfile.f` and `AbstractGradientProfile.grad` go through Symbolics' `@register_symbolic` macro, which gets `eval`'d in the `Main` scope, constructing `ConditionSet`s with more than one of each of these types of condition led to all but the first instance's `f`/`grad` method being overwritten.

For example, in the following `ConditionSet`:

```julia
conditions = ConditionSet(Dict(
    :T => LinearGradientProfile(;
        rate = 50.0,
        X_start = 300.0,
        X_end = 1000.0
    ),
    :P => LinearGradientProfile(;
        rate = 500.0,
        X_start = 1e5,
        X_end = 1.5e5
    )
))
```

since two `LinearGradientProfile`s were defined, the temperature profile would be constructed correctly with the requested `profile.grad` method added to Symbolics' computation graph, but the pressure profile would then overwrite this method with its own, as the computation graph is defined in the global scope and both of these functions therefore equate to a globally accessible function called `grad`.

To fix this, all direct/gradient profiles now have their respective inner methods defined with a unique name, created from a module-accessible counter (`Kinetica._n_direct_condition_functions` or `Kinetica._n_gradient_condition_functions` respectively) that is incremented with each variable condition profile that is instantiated. These functions are still accessible from their condition profile structs under the usual fields.

A side effect to this is that the original definitions for these methods has to also take place in the global scope, as '@eval` is required to construct uniquely-named functions at runtime. This means that these methods cannot take advantage of the data in their surrounding outer constructor methods, and it must be passed to them manually. 

All instances of `profile.f` or `profile.grad` now therefore take two arguments: the (potentially symbolic variable) time `t` and the condition profile that they are within, as these are not methods of the condition profile structs and do not have access to their data. This works with Symbolics thanks to its ability ti not overload specific arguments when given a type (see https://symbolics.juliasymbolics.org/dev/manual/functions/#Registration-API). This is therefore completely valid:

https://github.com/Kinetica-jl/Kinetica.jl/blob/b9282a2e28e8481a7932bb484b1ad37e2721f5c1/src/conditions/gradient_variable.jl#L45