### PR TITLE
Fix OpenBabel segfault in `frame_to_rdkit`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Kinetica"
 uuid = "3847ce11-53ec-444b-aa85-3b6606472139"
 authors = ["joegilkes <j.gilkes@warwick.ac.uk>"]
-version = "0.5.7"
+version = "0.5.8"
 
 [deps]
 BSON = "fbb218c0-5317-5bc6-957e-2ee96dd4b1f0"

--- a/src/rdkit/rdkit.jl
+++ b/src/rdkit/rdkit.jl
@@ -51,14 +51,7 @@ function frame_to_rdkit(frame::Dict{String, Any}; with_coords=false)
         rdmol.AddAtom(rdatom)
     end
 
-    for obbond in pybel.ob.OBMolBondIter(pbmol.OBMol)
-        a1 = obbond.GetBeginAtom()
-        a2 = obbond.GetEndAtom()
-        idx1 = a1.GetIdx()
-        idx2 = a2.GetIdx()
-        rdmol.AddBond(idx1-1, idx2-1, rdChem.rdchem.BondType.SINGLE)
-    end
-    rdmol = rdmol.GetMol()
+    rdmol = frame_to_rdkit_remap_atoms(pbmol, rdmol)
 
     if with_coords
         conf = rdChem.Conformer(frame["N_atoms"])


### PR DESCRIPTION
Back when we were using PyCall instead of PythonCall, there was an issue where repeated calling of `frame_to_rdkit` could cause a segfault within OpenBabel (as in the original implementation in 86ad962). This was originally fixed in 96539b7 by creating a pure Python function that could run this part of the code. No idea why this fix works, but it seems OB doesn't like being passed back and forth between Python and Julia very quickly and this works around it.

When we moved to PythonCall in e06ad7b it seemed like this was fixed and we went back to a mixed Julia/Python implementation of this functionality, but recent testing on large CRNs has caused it to rear its ugly head again. 

This has been fixed by reimplementing a pure Python function called `frame_to_rdkit_remap_atoms` in Kinetica's `__init__` function, using PythonCall this time.