### PR TITLE
Allow CRN modification after solve in explorations

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Kinetica"
 uuid = "3847ce11-53ec-444b-aa85-3b6606472139"
 authors = ["joegilkes <j.gilkes@warwick.ac.uk>"]
-version = "0.5.9"
+version = "0.5.10"
 
 [deps]
 BSON = "fbb218c0-5317-5bc6-957e-2ee96dd4b1f0"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Kinetica"
 uuid = "3847ce11-53ec-444b-aa85-3b6606472139"
 authors = ["joegilkes <j.gilkes@warwick.ac.uk>"]
-version = "0.5.8"
+version = "0.5.9"
 
 [deps]
 BSON = "fbb218c0-5317-5bc6-957e-2ee96dd4b1f0"


### PR DESCRIPTION
The `copy_network` kwarg of `solve_network` was previously inaccessible when running any CRN explorations. This causes problems for KineticaASE-based solves under `IterativeExplore`, as each call to `setup_network(sd, rd, calc::ASENEBCalculator)` creates a clash between the calculator's internal `RxData` cache and the updated 'real' `RxData`.

This is solved by introducing a new field to `DirectExplore` and `IterativeExplore` called `modify_network_on_solve`, which defaults to `true` and sets the correct value of `copy_network` to allow for modified `RxData`s to be returned to the caller.