### PR TITLE
Fix inactive species in unrendered CRN graphs & update paper references

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ For information on installation, usage and development of Kinetica.jl, see the [
 
 If you use Kinetica.jl in your research, please cite the following paper:
 
-> ```Gilkes, J.; Storr, M.; Maurer, R. J.; Habershon, S. Predicting long timescale kinetics under variable experimental conditions with Kinetica.jl. 2024, arXiv:2403.08657. arXiv.org e-Print archive. https://arxiv.org/abs/2403.08657```
+> ```Gilkes, J., Storr, M. T., Maurer, R. J., & Habershon, S. (2024). Predicting Long-Time-Scale Kinetics under Variable Experimental Conditions with Kinetica.jl. Journal of Chemical Theory and Computation, 20(12), 5196–5214. https://doi.org/10.1021/acs.jctc.4c00333```
 
 ## License
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -74,7 +74,7 @@ If you use any of the Kinetica packages in your work, please cite the following:
 
 ### Kinetica.jl
 
-> ```Gilkes, J.; Storr, M.; Maurer, R. J.; Habershon, S. Predicting long timescale kinetics under variable experimental conditions with Kinetica.jl. 2024, arXiv:2403.08657. arXiv.org e-Print archive. https://arxiv.org/abs/2403.08657```
+> ```Gilkes, J., Storr, M. T., Maurer, R. J., & Habershon, S. (2024). Predicting Long-Time-Scale Kinetics under Variable Experimental Conditions with Kinetica.jl. Journal of Chemical Theory and Computation, 20(12), 5196–5214. https://doi.org/10.1021/acs.jctc.4c00333```
 
 ### KineticaKPM.jl
 


### PR DESCRIPTION
Species that are not partaking in a CRN but are still present in an input `SpeciesData` due to reaction removal were always being included in CRN graphs rendered through `Catalyst.Graph`. This adds an option, `remove_inactive_species=true`, to the `Catalyst.Graph(sd, rd)` call, such that these species are removed from the graph by default but can be retained if desired.

Also updates the references on the readme and in the docs to the Kinetica paper.