### PR TITLE
Optional undirected levels at start of iterative exploration

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Kinetica"
 uuid = "3847ce11-53ec-444b-aa85-3b6606472139"
 authors = ["joegilkes <j.gilkes@warwick.ac.uk>"]
-version = "0.5.10"
+version = "0.5.11"
 
 [deps]
 BSON = "fbb218c0-5317-5bc6-957e-2ee96dd4b1f0"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Kinetica"
 uuid = "3847ce11-53ec-444b-aa85-3b6606472139"
 authors = ["joegilkes <j.gilkes@warwick.ac.uk>"]
-version = "0.5.9"
+version = "0.5.10"
 
 [deps]
 BSON = "fbb218c0-5317-5bc6-957e-2ee96dd4b1f0"


### PR DESCRIPTION
Some CRNs which are resistant to initial reaction require more reactions than the first level of an `IterativeExplore` alone can provide, in order to pull enough concentration flux over the primary reaction barrier(s) to combat more favourable backward reactions.

This PR adds a new option to `IterativeExplore`, `n_undirected_levels` (defaults to `0`), which forces seed species in the first levels to be taken directly from the current `SpeciesData`, rather than from a subset of these reactions with high enough maximum concentration. As such, exploration in these levels is undirected, hence the name. The default ensures that this won't trigger unless requested, i.e. `n_undirected_levels=1` will use all available species as seeds for the *second* level of exploration, as the first level is already undirected by design.