### PR TITLE
Improvements and fixes to reaction import

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Kinetica"
 uuid = "3847ce11-53ec-444b-aa85-3b6606472139"
 authors = ["joegilkes <joe@joegilk.es>"]
-version = "0.7.0"
+version = "0.7.1"
 
 [deps]
 BSON = "fbb218c0-5317-5bc6-957e-2ee96dd4b1f0"

--- a/src/exploration/explore_utils.jl
+++ b/src/exploration/explore_utils.jl
@@ -47,7 +47,7 @@ end
 
 
 """
-    import_mechanism(loc::ExploreLoc, rcount[, max_molecularity=2])
+    import_mechanism(loc::ExploreLoc, rcount[, max_molecularity=2, duplicate_reverse=true, unique_rxns=true])
 
 Create a CRN's initial `SpeciesData` and `RxData` from a CDE generated mechanism(s).
 
@@ -57,19 +57,26 @@ containing the unique species and reactions within these results,
 provided these reactions do not exceed the maximum molecularity
 set by `max_molecularity`, which defaults to only accepting
 unimolecular and bimolecular reactions.
+
+`duplicate_reverse` specifies whether to add the reverse reactions
+of each of the imported reactions. `unique_rxns` specifies whether
+to only add unique reactions to `RxData`.
 """
-function import_mechanism(loc::ExploreLoc, rcount; max_molecularity=2)
+function import_mechanism(loc::ExploreLoc, rcount; 
+        max_molecularity=2, duplicate_reverse=true, unique_rxns=true)
     rdir = pathof(loc)
-    rsmis, rxyzs, rsys, psmis, pxyzs, psys, dHs = ingest_cde_run(rdir, rcount)
+    rsmis, rxyzs, rsys, psmis, pxyzs, psys, dHs = ingest_cde_run(rdir, rcount; 
+                                                                 duplicate_reverse=duplicate_reverse)
     all_smis = vcat(reduce(vcat, rsmis), reduce(vcat, psmis))
     all_xyzs = vcat(reduce(vcat, rxyzs), reduce(vcat, pxyzs))
     sd = SpeciesData(all_smis, all_xyzs, loc.level)
-    rd = RxData(sd, rsmis, psmis, rsys, psys, dHs, loc.level; max_molecularity=max_molecularity)
+    rd = RxData(sd, rsmis, psmis, rsys, psys, dHs, loc.level; 
+                max_molecularity=max_molecularity, unique_rxns=unique_rxns)
     return sd, rd
 end
 
 """
-    import_mechanism!(sd::SpeciesData, rd::RxData, loc::ExploreLoc, rcount[, max_molecularity=2])
+    import_mechanism!(sd::SpeciesData, rd::RxData, loc::ExploreLoc, rcount[, max_molecularity=2, duplicate_reverse=true, unique_rxns=true])
 
 Extend a CRN's `SpeciesData` and `RxData` from a CDE generated mechanism(s).
 
@@ -79,15 +86,21 @@ species and reactions within these results, provided these
 reactions do not exceed the maximum molecularity set by 
 `max_molecularity`, which defaults to only accepting unimolecular
 and bimolecular reactions.
+
+`duplicate_reverse` specifies whether to add the reverse reactions
+of each of the imported reactions. `unique_rxns` specifies whether
+to only add unique reactions to `RxData`.
 """
 function import_mechanism!(sd::SpeciesData, rd::RxData, loc::ExploreLoc, rcount;
-        max_molecularity=2)
+        max_molecularity=2, duplicate_reverse=true, unique_rxns=true)
     rdir = pathof(loc)
-    rsmis, rxyzs, rsys, psmis, pxyzs, psys, dHs = ingest_cde_run(rdir, rcount)
+    rsmis, rxyzs, rsys, psmis, pxyzs, psys, dHs = ingest_cde_run(rdir, rcount; 
+                                                                 duplicate_reverse=duplicate_reverse)
     all_smis = vcat(reduce(vcat, rsmis), reduce(vcat, psmis))
     all_xyzs = vcat(reduce(vcat, rxyzs), reduce(vcat, pxyzs))
     push_unique!(sd, all_smis, all_xyzs, loc.level)
-    push!(rd, sd, rsmis, psmis, rsys, psys, dHs, loc.level; max_molecularity=max_molecularity)
+    push!(rd, sd, rsmis, psmis, rsys, psys, dHs, loc.level;
+          max_molecularity=max_molecularity, unique_rxns=unique_rxns)
     return
 end
 


### PR DESCRIPTION
Fixes #42 

Adds passthrough kwargs to `import_mechanism` and `import_mechanism!` for controlling whether reverse reactions should be created (on by default) and whether duplicate reactions should be discarded (also on by default).