### PR TITLE
Fixed incorrect chunk counting in chunkwise simulations

### DIFF
--- a/src/solving/methods.jl
+++ b/src/solving/methods.jl
@@ -588,11 +588,15 @@ function solve_network(method::VariableODESolve, sd::SpeciesData, rd::RxData, ::
         chunk_tf = method.pars.solve_chunkstep
         if nc == n_chunks_reqd-1
             # Handle floating point inaccuracies in final timestep.
-            last_global_time = tstops_local[end] + nc*method.pars.solve_chunkstep
-            if last_global_time == method.pars.tspan[2]
-                chunk_tf = tstops_local[end]
-            else
+            if length(tstops_local) == 0
                 push!(tstops_local, method.pars.solve_chunkstep)
+            else
+                last_global_time = tstops_local[end] + nc*method.pars.solve_chunkstep
+                if last_global_time == method.pars.tspan[2]
+                    chunk_tf = tstops_local[end]
+                else
+                    push!(tstops_local, method.pars.solve_chunkstep)
+                end
             end
         end
         reinit!(integ, integ.sol.u[end]; tstops=tstops_local, tf=chunk_tf)
@@ -801,11 +805,15 @@ function solve_network(method::VariableODESolve, sd::SpeciesData, rd::RxData, ::
         chunk_tf = method.pars.solve_chunkstep
         if nc == n_chunks_reqd-1
             # Handle floating point inaccuracies in final timestep.
-            last_global_time = tstops_local[end] + nc*method.pars.solve_chunkstep
-            if last_global_time == method.pars.tspan[2]
-                chunk_tf = tstops_local[end]
-            else
+            if length(tstops_local) == 0
                 push!(tstops_local, method.pars.solve_chunkstep)
+            else
+                last_global_time = tstops_local[end] + nc*method.pars.solve_chunkstep
+                if last_global_time == method.pars.tspan[2]
+                    chunk_tf = tstops_local[end]
+                else
+                    push!(tstops_local, method.pars.solve_chunkstep)
+                end
             end
         end
         reinit!(integ, integ.sol.u[end]; tstops=tstops_local, tf=chunk_tf)


### PR DESCRIPTION
Chunkwise simulations with variable conditions would sometimes fail depending on how time stops were being divided across the global timescale, which would manifest as certain `ConditionSet`s yielding `InexactError`s on conversion of `Float64`s to `Int`s.

This was caused by

1. local chunk time being counted incorrectly
2. any (minor) floating point imprecisions on final save point calculation exceeding the timescale allowed by `k_precalc` interpolation.

Both have now been fixed, so chunkwise simulations should be much more stable across different `ConditionSet`s and timescales.