### PR TITLE
Updated example paths in docs

### DIFF
--- a/docs/src/getting-started.md
+++ b/docs/src/getting-started.md
@@ -84,11 +84,11 @@ In order to perform a CRN exploration, an exploration method must be chosen. Kin
 
 [`DirectExplore`](@ref) explores all chemical reactions within a given radius of the starting reactants, irrespective of whether they will occur within a later kinetic simulation under the selected environmental conditions. This method is best suited to small CRNs under kinetically slow conditions, where few reactions are possible and complete sampling of all available reactions is easy.
 
-Reactions are sampled using [CDE](https://github.com/HabershonLab/cde), an external code for graph-driven sampling of reactions that is included with Kinetica.jl. CDE has its own parameters which must be set, but these are usually very similar for most CRN explorations. As such, a directory of template inputs must be provided for CDE to function. We provide such a template directory with this documentation, which can be used to run this tutorial. If you have cloned this documentation's repository, as suggested at the start of this tutorial, these files are in `KineticaDocs.jl/examples/cde_template`.
+Reactions are sampled using [CDE](https://github.com/HabershonLab/cde), an external code for graph-driven sampling of reactions that is included with Kinetica.jl. CDE has its own parameters which must be set, but these are usually very similar for most CRN explorations. As such, a directory of template inputs must be provided for CDE to function. We provide such a template directory with this documentation, which can be used to run this tutorial. If you have cloned this documentation's repository, as suggested at the start of this tutorial, these files are in `Kinetica.jl/examples/cde_template`.
 
-Once this is done, the exploration parameters can be set up as follows:
+Once this is done, the exploration parameters can be set up as follows (assuming you are working in the `examples` directory):
 
-```@example getting_started
+```julia
 crn_dir = "./my_CRN"
 
 exploremethod = DirectExplore(
@@ -96,11 +96,16 @@ exploremethod = DirectExplore(
     reac_smiles = ["C"],
     rxn_convergence_threshold = 5,
     cde = CDE(
-        template_dir = "../../examples/cde_template",
+        template_dir = "./cde_template",
         radius = 5,
         sampling_seed = 1
     )
 )
+```
+
+```@example getting_started
+crn_dir = "./my_CRN" # hide
+exploremethod = DirectExplore(rdir_head = crn_dir, reac_smiles = ["C"], rxn_convergence_threshold = 5, cde = CDE(template_dir = "../../examples/cde_template", radius = 5, sampling_seed = 1)) # hide
 ```
 
 The parameters defined in this block are as follows:
@@ -129,11 +134,16 @@ The main Kinetica.jl package only includes one kinetic calculator, the [`Precalc
 k = Ae^{-\dfrac{E_a}{RT}}
 ```
 
-The [`PrecalculatedArrheniusCalculator`](@ref) requires vectors of Arrhenius prefactors `A` and activation energies `Ea` for all reactions before the code is executed, and as such is typically only used when a CRN has been generated and these values have been determined outside Kinetica. However, for the purposes of this tutorial (where the random seed for CDE's reaction generation has been set, see above), we know the reactions that are going to be generated in advance, so we have provided approximate values to input into this calculator. These values are in `KineticaDocs.jl/examples/getting_started/arrhenius_params.bson`, and can be loaded in with:
+The [`PrecalculatedArrheniusCalculator`](@ref) requires vectors of Arrhenius prefactors `A` and activation energies `Ea` for all reactions before the code is executed, and as such is typically only used when a CRN has been generated and these values have been determined outside Kinetica. However, for the purposes of this tutorial (where the random seed for CDE's reaction generation has been set, see above), we know the reactions that are going to be generated in advance, so we have provided approximate values to input into this calculator. These values are in `Kinetica.jl/examples/getting_started/arrhenius_params.bson`, and can be loaded in with:
+
+```julia
+using BSON
+calc_pars = BSON.load("./getting_started/arrhenius_params.bson")
+```
 
 ```@example getting_started
-using BSON
-calc_pars = BSON.load("../../examples/getting_started/arrhenius_params.bson")
+using BSON # hide
+calc_pars = BSON.load("../../examples/getting_started/arrhenius_params.bson") # hide
 ```
 
 again, replacing this path with the equivalent path on your computer. The calculator for this CRN can now be constructed:

--- a/docs/src/tutorials/filtering-crns.md
+++ b/docs/src/tutorials/filtering-crns.md
@@ -6,11 +6,16 @@ Kinetica enables this reaction filtering through an easily extensible system tha
 
 To demonstrate, let's construct an [`RxFilter`](@ref) which removes all reactions involving double bonds from a CRN. We'll use the CRN we created in [Getting Started](@ref) by loading the results file and extracting the [`SpeciesData`](@ref) and [`RxData`](@ref):
 
-```@example filters
+```julia
+using Kinetica
+res = load_output("./my_CRN_out/direct_network_final.bson")
+sd, rd = res.sd, res.rd
+```
+
+```@setup filters
 using Kinetica
 res = load_output("../my_CRN_out/direct_network_final.bson")
-sd, rd = res.sd, res.rd
-nothing # hide
+sd, rd = res.sd, res.rd;
 ```
 
 If we inspect the reactions in this CRN, we can see that quite a few of them involve double bonds (represented in SMILES by an equals sign `=` between two elements):

--- a/docs/src/tutorials/iterative-exploration.md
+++ b/docs/src/tutorials/iterative-exploration.md
@@ -44,7 +44,7 @@ exploremethod = IterativeExplore(
     seed_conc = 0.05,
     independent_blacklist = ["[H]"],
     cde = CDE(
-        template_dir = "../../examples/cde_template",
+        template_dir = "./cde_template",
         radius = 1
     )
 )

--- a/docs/src/tutorials/ode-solution.md
+++ b/docs/src/tutorials/ode-solution.md
@@ -249,12 +249,16 @@ This parameter allows a vector-valued `u0` (as opposed to a `Dict`-based `u0 sho
 
 We will start by loading in the results from [Getting Started](@ref) and extracting the underlying CRN. For more information on loading saved CRNs, see [Saving & Loading](@ref).
 
-```@example ode_solution
+```julia
 using Kinetica
-
-res = load_output("../my_CRN_out/direct_network_final.bson")
+res = load_output("./my_CRN_out/direct_network_final.bson")
 sd, rd = res.sd, res.rd
-nothing # hide
+```
+
+```@setup ode_solution
+using Kinetica
+res = load_output("../my_CRN_out/direct_network_final.bson")
+sd, rd = res.sd, res.rd;
 ```
 
 !!! note "CRN Representation"
@@ -293,10 +297,16 @@ Here we've specified that the rate update timestep ``\tau_r`` should be 1 ms - t
 
 We'll set up the kinetic calculator in the same way as before:
 
-```@example ode_solution
+```julia
 using BSON
-calc_pars = BSON.load("../../../examples/getting_started/arrhenius_params.bson")
+calc_pars = BSON.load("./getting_started/arrhenius_params.bson")
 calc = PrecalculatedArrheniusCalculator(calc_pars[:Ea], calc_pars[:A]; k_max=1e12)
+```
+
+```@example ode_solution
+using BSON # hide
+calc_pars = BSON.load("../../../examples/getting_started/arrhenius_params.bson") # hide
+calc = PrecalculatedArrheniusCalculator(calc_pars[:Ea], calc_pars[:A]; k_max=1e12) # hide
 ```
 
 Now all that's left is to run the simulation. This can be achieved with [`solve_network`](@ref):

--- a/docs/src/tutorials/results-analysis.md
+++ b/docs/src/tutorials/results-analysis.md
@@ -10,10 +10,14 @@ Upon completion of a kinetic simulation run by [`solve_network`](@ref) (or throu
 
 We will demonstrate this analysis using the results of the CRN we generated and simulated in [Getting Started](@ref):
 
-```@example results_analysis
+```julia
 using Kinetica
-res = load_output("../my_CRN_out/direct_network_final.bson")
-nothing # hide
+res = load_output("./my_CRN_out/direct_network_final.bson")
+```
+
+```@setup results_analysis
+using Kinetica
+res = load_output("../my_CRN_out/direct_network_final.bson");
 ```
 
 ## Analysing the CRN

--- a/docs/src/tutorials/saving-loading.md
+++ b/docs/src/tutorials/saving-loading.md
@@ -30,11 +30,9 @@ Saving simulation outputs this way destructures them into core Julia objects onl
 
 Saved CRN results can be loaded back in to Julia through two methods. If loaded back in using Kinetica's [`load_output`](@ref) function, the serialised BSON gets reconstructed into a new [`ODESolveOutput`](@ref). Taking the CRN we generated and simulated in [Getting Started](@ref) as an example:
 
-```@example saving_loading
+```julia
 using Kinetica
-
-res = load_output("../my_CRN_out/direct_network_final.bson");
-nothing # hide
+res = load_output("./my_CRN_out/direct_network_final.bson");
 ```
 
 !!! note "Suppressing Output"
@@ -42,9 +40,14 @@ nothing # hide
 
 While every effort is made to maintain compatibility between saved outputs between Kinetica versions, we cannot guarantee that the internal structure of [`ODESolveOutput`](@ref)s will never change. If this happens in a way that cannot be worked around when reconstructing within [`load_output`](@ref), or if you wish to load the data in an environment without Kinetica, the output can still be loaded in as a raw BSON `Dict` tree:
 
-```@example saving_loading
+```julia
 using BSON
-out_raw = BSON.load("../my_CRN_out/direct_network_final.bson")
+out_raw = BSON.load("./my_CRN_out/direct_network_final.bson")
+```
+
+```@example saving_loading
+using BSON # hide
+out_raw = BSON.load("../my_CRN_out/direct_network_final.bson") # hide
 ```
 
 This allows users to flexibly access generated CRNs and kinetic simulation results, even when Kinetica is unavailable.


### PR DESCRIPTION
Aims to eliminate confusion and potential for accidental recursive file copying when users run tutorials from the docs.

Docs stated users should run out of `examples` directory in Kinetica repo, but then referenced other file paths to support running `@example` blocks in the correct places. This splits those blocks into displayed code and actually run code to always show the correct directories to documentation users.